### PR TITLE
awaiting while the metrics are calculated

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -127,8 +127,8 @@ export default class MarqueeText extends PureComponent<IMarqueeTextProps, IMarqu
     const callback = () => {
       this.setState({ animating: true });
 
-      this.setTimeout(() => {
-        this.calculateMetrics();
+      this.setTimeout(async () => {
+        await this.calculateMetrics();
 
         if (!this.contentFits) {
           Animated.timing(this.animatedValue, {


### PR DESCRIPTION
Hi.
I faced an issue when animation can start before the metrics are calculated because calculateMetrics method is asynchronous and contentFits initial value is false.

I've solved this by adding await operator.