### PR TITLE
Fix for bug with custom opacity

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -42,7 +42,7 @@ export default class MarqueeText extends PureComponent<IMarqueeTextProps, IMarqu
     marqueeOnStart: false,
     marqueeDelay: 0,
     marqueeResetDelay: 0,
-    onMarqueeComplete: () => {},
+    onMarqueeComplete: () => { },
     useNativeDriver: true,
   };
 
@@ -215,11 +215,11 @@ export default class MarqueeText extends PureComponent<IMarqueeTextProps, IMarqu
   render(): ReactNode {
     const { children, style, ...rest } = this.props;
     const { animating } = this.state;
-    const { width, height } = StyleSheet.flatten(style);
+    const { width, height, opacity } = StyleSheet.flatten(style);
 
     return (
       <View style={[styles.container, { width, height }]}>
-        <Text numberOfLines={1} {...rest} style={[style, { opacity: animating ? 0 : 1 }]}>
+        <Text numberOfLines={1} {...rest} style={[style, { opacity: opacity ? 0 : animating ? 0 : 1 }]}>
           {children}
         </Text>
         <ScrollView


### PR DESCRIPTION
There is an issue with the current release which causes an issue with the text if the default `opacity` style prop is changed when calling the component. For instance, if someone were to call the `<MarqueeText>` component as follows,

``` javascript
    <MarqueeText
          style={{ opacity: 0.5 }} // changing the default opacity
          duration={3000}
          marqueeOnStart
          loop
          marqueeDelay={1000}
          marqueeResetDelay={1000}
        >
          Lorem Ipsum is simply dummy text of the printing and typesetting industry and typesetting industry.
        </MarqueeText>
```

then, a bug would cause the specified `opacity: 0.5` to take effect only once the text starts to move. Moreover, if the length of the string is short enough that there is no need for the marquee animation, then the whole text would stay at the default opacity.

This pull request fixes the same.